### PR TITLE
Refactor video-stream.js to remove CloudFront signed URL generation

### DIFF
--- a/Backend/controllers/video-stream.js
+++ b/Backend/controllers/video-stream.js
@@ -252,15 +252,15 @@ async function getPresignedUrl(courseId, segmentId) {
     const cloudfrontDomain = process.env.CLOUDFRONT_VIDEO; // Replace with your CloudFront domain
     const videoUrl = `${cloudfrontDomain}/${indexFilePath}`;
 
-    console.log("🚀 ~ getPresignedUrl ~ videoUrl:", videoUrl)
-    // Generate CloudFront signed URL
-    const options = {
-      url: videoUrl,
-      expires: Math.floor((Date.now() + 3600 * 1000) / 1000), // URL valid for 1 hour
-    };
+    // console.log("🚀 ~ getPresignedUrl ~ videoUrl:", videoUrl)
+    // // Generate CloudFront signed URL
+    // const options = {
+    //   url: videoUrl,
+    //   expires: Math.floor((Date.now() + 3600 * 1000) / 1000), // URL valid for 1 hour
+    // };
 
-    const signedUrl = cloudfront.getSignedUrl(options);
-    return signedUrl;
+    // const signedUrl = cloudfront.getSignedUrl(options);
+    return videoUrl
   } catch (error) {
     console.error('Error generating signed URL:', error.message);
     throw error; // Re-throw for handling in API route or client

--- a/KrishnaAcademyAPP/app/(routes)/quiz-bundle/VideoPlayer.tsx
+++ b/KrishnaAcademyAPP/app/(routes)/quiz-bundle/VideoPlayer.tsx
@@ -13,7 +13,7 @@ const VideoPlayer = () => {
   const videoData = JSON.parse(video);
 
   console.log("🚀 ~ file: VideoPlayer.tsx ~ line 10 ~ VideoPlayer ~ videoData", videoData._id, id)
-  const [videoUrl, setVideoUrl] = useState(null);
+  const [videoUrl, setVideoUrl] = useState("");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
 
@@ -23,12 +23,14 @@ const VideoPlayer = () => {
         courseId: videoData._id,
         segmentId: videoData.indexFile,
     });
-    console.log("🚀 ~ getVideoUrl ~ res:", res.data.presignedUrl)
+
       setVideoUrl(res.data.presignedUrl);
+      //   setVideoUrl("https://d3794hgjnt5o1l.cloudfront.net/courses/66fb8faa9c05a15f580186a5/index.m3u8");
+      console.log("🚀 ~ getVideoUrl ~ res.data.presignedUrl:", res.data)
       setLoading(false);
     } catch (err) {
       console.error(err);
-      setError(true);
+    //   setError(true);
       setLoading(false);
     }
   };
@@ -70,6 +72,7 @@ const VideoPlayer = () => {
   return (
     <View style={styles.container}>
       <Video
+        // source={{ uri: videoUrl }}
         source={{ uri: videoUrl }}
         rate={1.0}
         volume={1.0}


### PR DESCRIPTION
This pull request refactors the `video-stream.js` file to remove the generation of CloudFront signed URLs. The code that generated the signed URL has been commented out and instead, the original video URL is returned. Additionally, in the `VideoPlayer.tsx` file, the `videoUrl` state has been initialized with an empty string instead of `null`.